### PR TITLE
Remove spurious lang attribute from English-language book title in long description

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -43,7 +43,7 @@
 		<dc:description id="description">A Polish woman aims to find love in a society of shifting moral norms.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
 			&lt;p&gt;Janka has emerged from her “ice-plains,” her cerebral realms of pure thought, to bask in the strong sunshine of life. A summer with a friend has introduced her to a love-addled suitor, but her heart is fixed on another’s more intellectual charms. Meanwhile, the difference in how Polish society accepts men and women’s actions is becoming increasingly apparent to Janka and her wider group of associates.&lt;/p&gt;
-			&lt;p&gt;&lt;i lang="pl"&gt;Women&lt;/i&gt; is &lt;a href="https://standardebooks.org/ebooks/zofia-nalkowska"&gt;Zofia Nałkowska’s&lt;/a&gt; first novel. The first part was published in &lt;i&gt;The Truth&lt;/i&gt; in 1904; the remaining two parts were published in 1906, completing the book right in the middle of the modernist Young Poland movement. This translation was published in 1920.&lt;/p&gt;
+			&lt;p&gt;&lt;i&gt;Women&lt;/i&gt; is &lt;a href="https://standardebooks.org/ebooks/zofia-nalkowska"&gt;Zofia Nałkowska’s&lt;/a&gt; first novel. The first part was published in &lt;i&gt;The Truth&lt;/i&gt; in 1904; the remaining two parts were published in 1906, completing the book right in the middle of the modernist Young Poland movement. This translation was published in 1920.&lt;/p&gt;
 		</meta>
 		<dc:language>en-GB</dc:language>
 		<dc:source>https://www.gutenberg.org/ebooks/61618</dc:source>


### PR DESCRIPTION
The book title (`Women`) was marked as Polish in the long description, probably from before the title was changed from the Polish original to the English translation.